### PR TITLE
Fix blog: switch RSS → Hashnode GraphQL; remove Umami

### DIFF
--- a/app/_components/blog.tsx
+++ b/app/_components/blog.tsx
@@ -1,5 +1,3 @@
-import { XMLParser } from 'fast-xml-parser';
-
 import { PopoverViewer } from '@/components/popover/popover-viewer';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
@@ -18,59 +16,69 @@ type ParsedArticle = {
   description: string;
 };
 
-type RssItem = {
+type HashnodePostNode = {
   title: string;
-  link: string;
-  description: string;
-  pubDate: string;
-  'content:encoded'?: string;
+  brief: string;
+  url: string;
+  publishedAt: string;
+  coverImage: { url: string } | null;
 };
+
+type HashnodeResponse = {
+  data?: {
+    publication?: {
+      posts?: {
+        edges?: { node: HashnodePostNode }[];
+      };
+    };
+  };
+};
+
+const HASHNODE_QUERY = `
+  query PublicationPosts($host: String!, $first: Int!) {
+    publication(host: $host) {
+      posts(first: $first) {
+        edges {
+          node {
+            title
+            brief
+            url
+            publishedAt
+            coverImage { url }
+          }
+        }
+      }
+    }
+  }
+`;
 
 async function fetchArticles(): Promise<ParsedArticle[]> {
   try {
-    const response = await fetch(
-      'https://blog.gshahdev.com/rss.xml',
-      { next: { revalidate: 3600 } } // Cache for 1 hour
-    );
+    const response = await fetch('https://gql.hashnode.com/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        query: HASHNODE_QUERY,
+        variables: { host: 'blog.gshahdev.com', first: 10 },
+      }),
+      next: { revalidate: 3600 },
+    });
 
     if (!response.ok) {
-      console.error('RSS fetch failed:', response.status);
+      console.error('Hashnode fetch failed:', response.status);
       return [];
     }
 
-    const xml = await response.text();
+    const json = (await response.json()) as HashnodeResponse;
+    const edges = json?.data?.publication?.posts?.edges ?? [];
 
-    const parser = new XMLParser({
-      ignoreAttributes: false,
-      attributeNamePrefix: '@_',
-    });
-
-    const parsed = parser.parse(xml);
-    const items = parsed?.rss?.channel?.item;
-
-    if (!items?.length) {
-      return [];
-    }
-
-    return items.map((item: RssItem) => {
-      // Extract first image from content:encoded if available
-      const content = item['content:encoded'] || '';
-      const imgMatch = content.match(/<img[^>]+src=["']([^"']+)["']/);
-      const thumbnail = imgMatch ? imgMatch[1] : '';
-
-      // Clean description - remove CDATA wrapper and HTML tags
-      const cleanDescription = (item.description || '')
-        .replace(/(<([^>]+)>)/gi, '')
-        .trim();
-
-      return {
-        title: truncate(item.title || '', 36),
-        thumbnail,
-        link: item.link || '',
-        pubDate: item.pubDate || '',
-        description: truncate(cleanDescription, 145),
-      };
-    });
+    return edges.map(({ node }) => ({
+      title: truncate(node.title || '', 36),
+      thumbnail: node.coverImage?.url ?? '',
+      link: node.url || '',
+      pubDate: node.publishedAt || '',
+      description: truncate(node.brief || '', 145),
+    }));
   } catch (error) {
     console.error('Blog fetch error:', error);
     return [];

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import type { Metadata } from 'next';
 import { GeistSans } from 'geist/font/sans';
 
 import RootProviders from './root-providers';
-import Script from 'next/script';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://gshahdev.com/'),
@@ -41,11 +40,7 @@ export default function RootLayout({
       <body className={GeistSans.className} suppressHydrationWarning>
         <RootProviders>{children}</RootProviders>
       </body>
-      <Script
-        defer
-        src="https://analytics.h1a1ah.com/script.js"
-        data-website-id="ef50a03a-9ed2-4cc7-a2a0-82a656995724"
-      />
+      {/* TODO: add Swetrix analytics — see infra/coolify-infra#88 */}
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- `app/_components/blog.tsx` — replace the `blog.gshahdev.com/rss.xml` fetch with the Hashnode GraphQL API (`https://gql.hashnode.com/`, `publication(host: "blog.gshahdev.com")`). The RSS URL is now blocked by a Vercel bot-protection challenge page, which caused `fetchArticles` to return an empty array and the home page blog section to render blank.
- `app/layout.tsx` — remove the Umami `<Script>` (analytics stack migration). Leaves a `// TODO` comment pointing to infra/coolify-infra#88 for the Swetrix rollout.

The `ParsedArticle` shape is preserved, so no JSX below `fetchArticles` changed.

## Why
The production site's blog section was empty because Vercel's edge protection now returns a 429 challenge page instead of the RSS feed. Hashnode's public GraphQL endpoint serves the same publication without auth and isn't rate-limited the same way.

## Verification
- `pnpm build` passes (all 16 routes, `/` prerendered static).
- Hashnode GraphQL confirmed returning posts for `blog.gshahdev.com` at query time.

## Out of scope
- `fast-xml-parser` dep removal — leaving in `package.json` to keep this PR minimal. Can be dropped in a follow-up.
- Swetrix wiring — tracked separately in infra/coolify-infra#88.